### PR TITLE
Update from upstream changes.

### DIFF
--- a/src/OpenMRNLite.cpp
+++ b/src/OpenMRNLite.cpp
@@ -34,6 +34,8 @@
 
 #include <OpenMRNLite.h>
 
+OVERRIDE_CONST(gridconnect_bridge_max_incoming_packets, 5);
+
 namespace openmrn_arduino {
 
 OpenMRN::OpenMRN(openlcb::NodeID node_id)

--- a/src/OpenMRNLite.h
+++ b/src/OpenMRNLite.h
@@ -39,6 +39,7 @@
 #include <Arduino.h>
 
 #include "CDIXMLGenerator.hxx"
+#include "executor/Notifiable.hxx"
 #include "freertos_drivers/arduino/Can.hxx"
 #include "freertos_drivers/arduino/WifiDefs.hxx"
 #include "openlcb/SimpleStack.hxx"
@@ -166,14 +167,26 @@ private:
     /// Handles data coming in from the serial port and sends it to OpenMRN.
     void loop_for_read()
     {
+        if (!bn_.is_done())
+        {
+            // Blocked because data we've just read has not yet been processed.
+            return;
+        }
         int av = port_->available();
         if (av <= 0)
         {
             return;
         }
+        // We don't read too many bytes into one buffer. 64 is exactly one USB
+        // packet's length.
+        if (av > 64)
+        {
+            av = 64;
+        }
         auto *b = txtHub_.alloc();
         b->data()->skipMember_ = &writePort_;
         b->data()->resize(av);
+        b->set_done(bn_.reset(EmptyNotifiable::DefaultInstance()));
         port_->readBytes((char*)b->data()->data(), b->data()->size());
         txtHub_.send(b);
     }
@@ -235,6 +248,14 @@ private:
     size_t writeOfs_;
     /// Hub for the textual data.
     HubFlow txtHub_{service_};
+    /// This notifiable will know whether the txt packet we read from the
+    /// serial has been processed by the hub. This is a pushback mechanism for
+    /// us not to run out of memory when there is too many packets coming from
+    /// the host or socket.
+    ///
+    /// This notifiable is active while there is a message in flight to the txt
+    /// hub.
+    BarrierNotifiable bn_;
 };
 
 /// Bridge class that connects a native CAN controller to the OpenMRN core

--- a/src/dcc/LocalTrackIf.cpp
+++ b/src/dcc/LocalTrackIf.cpp
@@ -46,6 +46,9 @@
 #else
 #include "can_ioctl.h"
 #endif
+
+#endif // OPENMRN_FEATURE_FD_CAN_DEVICE
+
 #include "dcc/LocalTrackIf.hxx"
 
 namespace dcc
@@ -58,6 +61,7 @@ LocalTrackIf::LocalTrackIf(Service *service, int pool_size)
 {
 }
 
+#if defined(OPENMRN_FEATURE_FD_CAN_DEVICE) || defined(GTEST)
 StateFlowBase::Action LocalTrackIf::entry()
 {
     HASSERT(fd_ >= 0);
@@ -65,11 +69,14 @@ StateFlowBase::Action LocalTrackIf::entry()
     int ret = write(fd_, p, sizeof(*p));
     if (ret < 0) {
         HASSERT(errno == ENOSPC);
+        #ifndef GTEST
         ::ioctl(fd_, CAN_IOC_WRITE_ACTIVE, this);
+        #endif
         return wait();
     }
     return finish();
 }
+#endif
 
 StateFlowBase::Action LocalTrackIfSelect::entry() {
     HASSERT(fd_ >= 0);
@@ -79,4 +86,3 @@ StateFlowBase::Action LocalTrackIfSelect::entry() {
 
 } // namespace dcc
 
-#endif // OPENMRN_FEATURE_FD_CAN_DEVICE

--- a/src/executor/StateFlow.hxx
+++ b/src/executor/StateFlow.hxx
@@ -355,9 +355,6 @@ protected:
         Pool *p = pool;
         if (!p)
         {
-            // GCC reports: warning: 'this' pointer is null [-Wnonnull] for
-            // target_flow, adding the HASSERT prevents the warning and null
-            // dereference.
             HASSERT(target_flow != nullptr);
             p = target_flow->pool();
         }

--- a/src/freertos_drivers/esp32/Esp32HardwareTwai.cpp
+++ b/src/freertos_drivers/esp32/Esp32HardwareTwai.cpp
@@ -233,7 +233,7 @@ static inline void twai_purge_rx_queue()
     Notifiable* n = nullptr;
     {
         AtomicHolder h(&twai.buf_lock);
-        LOG(VERBOSE, "ESP-TWAI: puring RX-Q:%zu", twai.rx_buf->pending());
+        LOG(VERBOSE, "ESP-TWAI: purging RX-Q: %zu", twai.rx_buf->pending());
         twai.stats.rx_missed += twai.rx_buf->pending();
         twai.rx_buf->flush();
         std::swap(n, twai.readable_notify);
@@ -259,7 +259,7 @@ static inline void twai_purge_tx_queue()
     Notifiable* n = nullptr;
     {
         AtomicHolder h(&twai.buf_lock);
-        LOG(VERBOSE, "ESP-TWAI: puring TX-Q:%zu", twai.tx_buf->pending());
+        LOG(VERBOSE, "ESP-TWAI: purging TX-Q: %zu", twai.tx_buf->pending());
         twai.stats.tx_failed += twai.tx_buf->pending();
         twai.tx_buf->flush();
         std::swap(n, twai.writable_notify);
@@ -793,9 +793,9 @@ static void twai_isr(void *arg)
     // Arbitration error detected
     if (events & TWAI_HAL_EVENT_ARB_LOST)
     {
-        twai.stats.arb_error++;
+        twai.stats.arb_loss++;
         ESP_EARLY_LOGV(TWAI_LOG_TAG, "arb-lost:%" PRIu32,
-                       twai.stats.arb_error);
+                       twai.stats.arb_loss);
     }
 
     if (wakeup == pdTRUE)
@@ -886,7 +886,7 @@ void* twai_watchdog(void* param)
                 twai.stats.rx_missed, twai.stats.rx_lost,
                 twai.stats.tx_processed, twai.tx_buf->pending(),
                 twai.stats.tx_success, twai.stats.tx_failed,
-                twai.stats.arb_error, twai.stats.bus_error,
+                twai.stats.arb_loss, twai.stats.bus_error,
                 is_twai_running() ? "Running" :
                 is_twai_recovering() ? "Recovering" :
                 is_twai_err_warn() ? "Err-Warn" :

--- a/src/freertos_drivers/esp32/Esp32HardwareTwai.hxx
+++ b/src/freertos_drivers/esp32/Esp32HardwareTwai.hxx
@@ -81,8 +81,8 @@ typedef struct
     /// by the low-level TWAI driver.
     uint32_t tx_failed;
 
-    /// Number of arbitration errors that have been observed on the TWAI bus.
-    uint32_t arb_error;
+    /// Number of arbitration losses that have been observed on the TWAI bus.
+    uint32_t arb_loss;
 
     /// Number of general bus errors that have been observed on the TWAI bus.
     uint32_t bus_error;

--- a/src/freertos_drivers/esp32/Esp32SocInfo.hxx
+++ b/src/freertos_drivers/esp32/Esp32SocInfo.hxx
@@ -34,6 +34,9 @@
 #ifndef _FREERTOS_DRIVERS_ESP32_ESP32SOCINFO_HXX_
 #define _FREERTOS_DRIVERS_ESP32_ESP32SOCINFO_HXX_
 
+#include <stdint.h>
+
+#if defined(ESP_PLATFORM)
 
 #include "sdkconfig.h"
 
@@ -50,7 +53,6 @@
 #elif defined(CONFIG_IDF_TARGET_ESP32C2)
 #include <esp32c2/rom/rtc.h>
 #endif
-#include <stdint.h>
 
 namespace openmrn_arduino
 {
@@ -68,5 +70,7 @@ public:
 } // namespace openmrn_arduino
 
 using openmrn_arduino::Esp32SocInfo;
+
+#endif // ESP_PLATFORM
 
 #endif // _FREERTOS_DRIVERS_ESP32_ESP32SOCINFO_HXX_

--- a/src/openlcb/AliasCache.cpp
+++ b/src/openlcb/AliasCache.cpp
@@ -515,7 +515,10 @@ NodeAlias AliasCache::lookup(NodeID id)
  */
 NodeID AliasCache::lookup(NodeAlias alias)
 {
-    HASSERT(alias != 0);
+    if (alias == 0)
+    {
+        return 0;
+    }
 
     auto it = aliasMap.find(alias);
 

--- a/src/openlcb/Bootloader.hxx
+++ b/src/openlcb/Bootloader.hxx
@@ -1048,10 +1048,6 @@ bool bootloader_init() {
 /// should keep running (i.e., to call again).
 bool bootloader_loop()
 {
-#ifdef BOOTLOADER_LOOP_HOOK
-    BOOTLOADER_LOOP_HOOK();
-#endif
-
     {
 #ifdef __linux__
         AtomicHolder h(&g_bootloader_lock);
@@ -1073,6 +1069,9 @@ bool bootloader_loop()
             g_bootloader_busy = new_busy;
         }
     }
+#ifdef BOOTLOADER_LOOP_HOOK
+    BOOTLOADER_LOOP_HOOK();
+#endif
     if (state_.output_frame_full && try_send_can_frame(state_.output_frame))
     {
         state_.output_frame_full = 0;

--- a/src/openlcb/BroadcastTime.cpp
+++ b/src/openlcb/BroadcastTime.cpp
@@ -47,15 +47,9 @@ namespace openlcb
 void BroadcastTime::clear_timezone()
 {
 #ifndef ESP_PLATFORM
-        setenv("TZ", "GMT0", 1);
-        tzset();
+    setenv("TZ", "GMT0", 1);
+    tzset();
 #endif
-}
-
-extern "C"
-{
-// normally requires _GNU_SOURCE
-char *strptime(const char *, const char *, struct tm *);
 }
 
 //
@@ -63,15 +57,12 @@ char *strptime(const char *, const char *, struct tm *);
 //
 void BroadcastTime::set_date_year_str(const char *date_year)
 {
-    struct tm tm;
-    if (strptime(date_year, "%b %e, %Y", &tm) != nullptr)
+    int year, month, day;
+    if (BroadcastTimeDefs::string_to_date(date_year, &year, &month, &day))
     {
-        if (tm.tm_year >= (0 - 1900) && tm.tm_year <= (4095 - 1900))
-        {
-            // date valid
-            set_date(tm.tm_mon + 1, tm.tm_mday);
-            set_year(tm.tm_year + 1900);
-        }
+        // date valid
+        set_date(month, day);
+        set_year(year);
     }
 }
 

--- a/src/openlcb/BroadcastTime.hxx
+++ b/src/openlcb/BroadcastTime.hxx
@@ -99,7 +99,7 @@ public:
     }
 
     /// Set the date and year from a C string.
-    /// @param data_year date and year format in "Mmm dd, yyyy" format
+    /// @param date_year date and year format in "Mmm dd, yyyy" format
     void set_date_year_str(const char *date_year);
 
     /// Set Rate. The new rate does not become valid until the update callbacks

--- a/src/openlcb/BroadcastTimeDefs.cpp
+++ b/src/openlcb/BroadcastTimeDefs.cpp
@@ -112,6 +112,26 @@ std::string BroadcastTimeDefs::rate_quarters_to_string(int16_t rate)
 }
 
 //
+// BroadcastTimeDefs::date_to_string()
+//
+std::string BroadcastTimeDefs::date_to_string(int year, int month, int day)
+{
+    struct tm tm = {};
+    tm.tm_year = year - 1900;
+    tm.tm_mon = month - 1;
+    tm.tm_mday = day;
+    char value[13];
+    if (strftime(value, 13, "%b %e, %Y", &tm) != 0)
+    {
+        return value;
+    }
+    else
+    {
+        return "Error";
+    }
+}
+
+//
 // BroadcastTimeDefs::string_to_time()
 //
 bool BroadcastTimeDefs::string_to_time(
@@ -146,7 +166,7 @@ int16_t BroadcastTimeDefs::string_to_rate_quarters(const std::string &srate)
     if (end == rate_c_str)
     {
         // None of the string processed.
-        return 0;
+        return 4;
     }
     if (rate < -512)
     {
@@ -161,6 +181,87 @@ int16_t BroadcastTimeDefs::string_to_rate_quarters(const std::string &srate)
     rate *= 4;
     rate += rate < 0 ? -0.5 : 0.5;
     return rate;
+}
+
+//
+// BroadcastTimeDefs::string_to_date()
+//
+bool BroadcastTimeDefs::string_to_date(
+    const std::string &sdate, int *year, int *month, int *day)
+{
+    struct tm tm;
+    memset(&tm, 0, sizeof(tm));
+    if (strptime(sdate.c_str(), "%b %e, %Y", &tm) == nullptr)
+    {
+        return false;
+    }
+
+    // newlib does not have the proper boundary checking for strptime().
+    // Therefore we use mktime() to determine if the time we have is really
+    // valid or not. In newlib, mktime() can actually correct some invalid
+    // struct tm values by making some educated guesses.
+    //
+    // While glibc does have proper boundary checking for strptime(), it
+    // can still use mktime() to correct some invalid struct tm values by
+    // making some educated guesses.
+    time_t t = mktime(&tm);
+
+    // newlib does not correctly set the errno value when mktime()
+    // encounters an error. Instead it "only" returns -1, which is technically
+    // a valid time. We are counting on the fact that we zeroed out the struct
+    // tm above, and subsequently -1 cannot be an expected result.
+    if (t == (time_t)-1)
+    {
+        return false;
+    }
+
+    if (tm.tm_year < (0 - 1900) || tm.tm_year > (4095 - 1900))
+    {
+        // Out of range for openlcb.
+        return false;
+    }
+    *year = tm.tm_year + 1900;
+    *month = tm.tm_mon + 1;
+    *day = tm.tm_mday;
+    return true;
+}
+
+bool BroadcastTimeDefs::canonicalize_rate_string(std::string *srate)
+{
+    int r = string_to_rate_quarters(*srate);
+    string out = rate_quarters_to_string(r);
+    if (out != *srate)
+    {
+        *srate = std::move(out);
+        return true;
+    }
+    return false;
+}
+
+bool BroadcastTimeDefs::canonicalize_date_string(std::string *sdate)
+{
+    int y = 1970, m = 1, d = 1;
+    string_to_date(*sdate, &y, &m, &d);
+    string out = date_to_string(y, m, d);
+    if (out != *sdate)
+    {
+        *sdate = std::move(out);
+        return true;
+    }
+    return false;
+}
+
+bool BroadcastTimeDefs::canonicalize_time_string(std::string *stime)
+{
+    int h = 0, m = 0;
+    string_to_time(*stime, &h, &m);
+    string out = time_to_string(h, m);
+    if (out != *stime)
+    {
+        *stime = std::move(out);
+        return true;
+    }
+    return false;
 }
 
 } // namespace openlcb

--- a/src/openlcb/BroadcastTimeDefs.hxx
+++ b/src/openlcb/BroadcastTimeDefs.hxx
@@ -353,6 +353,12 @@ struct BroadcastTimeDefs
     /// @return rate represented in the form of a string (float)
     static std::string rate_quarters_to_string(int16_t rate);
 
+    /// Converts a date to a string "Mmm dd, yyyy".
+    /// @param year 0 to 4095
+    /// @param month 1 to 12 (warning! struct tm has 0 to 11)
+    /// @param day 1 to 31
+    static std::string date_to_string(int year, int month, int day);
+    
     /// Convert a string (hh:mm) to hour and minute component integers.
     /// @param stime time in the form of a string
     /// @param hour resulting hour integer (0 to 23)
@@ -366,6 +372,40 @@ struct BroadcastTimeDefs
     ///         conversion error occurs, then the returned value will be 0,
     ///         which is at least a valid rate.
     static int16_t string_to_rate_quarters(const std::string &srate);
+
+    /// Converts a (user-provided) string "Mmm dd, yyyy" to date. Verifies that
+    /// the values are in range for OpenLCB and for a real date.
+    /// @param sdate the input string in "Mmm dd, yyyy" format.
+    /// @param year will be filled in with the year (0 to 4095)
+    /// @param month will be filled in with the month (1 to 12) (warning!
+    /// struct tm has 0 to 11)
+    /// @param day will be filled in with the day (1 to 31)
+    /// @return true on success, false on parse error. Note that it is not
+    /// fully specified what is a parse error; certain errors will be corrected
+    /// (e.g. feb 30, 2001 will be fixed to march 2).
+    static bool string_to_date(
+        const std::string &sdate, int *year, int *month, int *day);
+
+    /// Verifies that a user-provided string parses as time, and canonicalizes
+    /// the string format. Parse errors get turned into "00:00".
+    /// @param stime input-output argument. Input is the user-provided time
+    /// (hh:mm), output is the canonicalized time.
+    /// @return true if the string has changed during canonicalization.
+    static bool canonicalize_time_string(std::string *stime);
+
+    /// Verifies that a user-provided string parses as rate quarters, and
+    /// canonicalizes the string format. Parse errors get turned into "0.00".
+    /// @param srate input-output argument. Input is user-provided rate, output
+    /// is the canonicalized rate.
+    /// @return true if the string has changed during canonicalization.
+    static bool canonicalize_rate_string(std::string* srate);
+
+    /// Verifies that a user-provided string parses as date, and canonicalizes
+    /// the string format. Parse errors get turned into "Jan 1, 1970".
+    /// @param sdate input-output argument. Input is user-provided date in "Mmm
+    /// dd, yyyy" format, output is the canonicalized date.
+    /// @return true if the string has changed during canonicalization.
+    static bool canonicalize_date_string(std::string* sdate);
 };
 
 }  // namespace openlcb

--- a/src/openlcb/MemoryConfig.hxx
+++ b/src/openlcb/MemoryConfig.hxx
@@ -751,7 +751,9 @@ private:
 
         long long timeout() override
         {
+#if OPENMRN_FEATURE_REBOOT         
             reboot();
+#endif            
             return DELETE;
         }
     };

--- a/src/openmrn_features.h
+++ b/src/openmrn_features.h
@@ -37,6 +37,13 @@
 #ifndef _INCLUDE_OPENMRN_FEATURES_
 #define _INCLUDE_OPENMRN_FEATURES_
 
+#ifdef ESP_PLATFORM
+#include <esp_idf_version.h>
+#else
+#define ESP_IDF_VERSION 0
+#define ESP_IDF_VERSION_VAL(a,b,c) 1
+#endif // ESP_PLATFORM
+
 #ifdef __FreeRTOS__
 /// Compiles the FreeRTOS event group based ::select() implementation.
 #define OPENMRN_FEATURE_DEVICE_SELECT 1

--- a/src/os/os.h
+++ b/src/os/os.h
@@ -667,7 +667,7 @@ OS_INLINE int os_sem_post(os_sem_t *sem)
  */
 OS_INLINE int os_sem_post_from_isr(os_sem_t *sem, int *woken)
 {
-    portBASE_TYPE local_woken;
+    portBASE_TYPE local_woken = 0;
     xSemaphoreGiveFromISR(*sem, &local_woken);
     *woken |= local_woken;
     return 0;

--- a/src/utils/Base64.cpp
+++ b/src/utils/Base64.cpp
@@ -34,6 +34,7 @@
 
 #include "utils/Base64.hxx"
 
+#include <stdint.h>
 #include "utils/macros.h"
 
 static const char nib64[] =

--- a/src/utils/HubDeviceSelect.cpp
+++ b/src/utils/HubDeviceSelect.cpp
@@ -1,2 +1,10 @@
 
 #include "utils/HubDeviceSelect.hxx"
+
+#include "nmranet_config.h"
+
+/// @return the number of packets to limit read input if we are throttling.
+int hubdevice_incoming_packet_limit()
+{
+    return config_gridconnect_port_max_incoming_packets();
+}

--- a/src/utils/format_utils.hxx
+++ b/src/utils/format_utils.hxx
@@ -37,6 +37,7 @@
 
 #include <string>
 #include <string.h>
+#include <stdint.h>
 
 using std::string;
 


### PR DESCRIPTION
- apply pushback in OpenMRNLite when too much data is coming from an USB port.
- make localtrackif be compiled under linux
- Esp32 Bootloader updates: separate TX and TX timeout, bool rtc_true is a random word, error checking in the finaliz method
- arb_error is arb_loss.
- stm32 can workaround when it is alone on the bus
- aliascache should not crash when a message arrive with alias == 0.
- bootloader hook should see the incoming frame
- BroadcastTime has additional helper functions.
- callback event handler has support for identified handler.
- reboot is optionalized with a feature macro
- hubdeviceselect supports the pushback against an usb port

This PR, together with https://github.com/bakerstu/openmrn/pull/771 eliminates all diffs between openmrn and OpenMRNIDF.