### PR TITLE
Adds static dependencies instead of using the component manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,8 @@ set(IDF_DEPS
     espcoredump
     hal
     heap
-    vfs)
+    vfs
+    mdns)
 
 idf_component_register(SRC_DIRS "${SOURCE_DIRS}"
                        INCLUDE_DIRS "src"

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,3 +1,0 @@
-dependencies:
-  idf: ">=5.0"
-  espressif/mdns: "*"


### PR DESCRIPTION
- adds mdns as an explicit component dependency.
- removed idf_component.yml to allow not triggering the component manager.